### PR TITLE
Refactor: isolate api specific logic in API layer

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,9 +8,12 @@
         incanter/incanter {:mvn/version "1.9.3" :exclusions [com.lowagie/itext]}}
 
  :aliases
- {:test {:extra-paths ["src/test/clojure"]
+ {:examples {:extra-paths ["src/test/clojure" "examples"]
+             :extra-deps {org.clojure/test.check {:mvn/version "1.1.0"}}}}
+
+  :test {:extra-paths ["src/test/clojure"]
          :extra-deps {org.clojure/test.check {:mvn/version "1.1.0"}
                       com.cognitect/test-runner
                       {:local/root "../test-runner"}}
          :main-opts ["-m" "cognitect.test-runner"
-                     "-d" "src/test/clojure"]}}}
+                     "-d" "src/test/clojure"]}}

--- a/src/main/clojure/edmondson/google_api.clj
+++ b/src/main/clojure/edmondson/google_api.clj
@@ -14,10 +14,19 @@
         creds (cfg/google-credentials transport)
         factory (. JacksonFactory getDefaultInstance)
         service  (.. (new Sheets$Builder transport factory creds)
-                     (setApplicationName "survey-scorer")
+                     (setApplicationName "krukow/edmondson")
                      build)
         response (.. service (spreadsheets)
                      (values)
                      (get sheet range)
                      execute)]
     (seq (.getValues response))))
+
+
+(defn normalize-responses
+  [survey-questions responses]
+  (map-indexed (fn [n response]
+                 {:responseId n
+                  :meta-data {}
+                  :answers (zipmap survey-questions response)})
+               responses))

--- a/src/main/clojure/edmondson/qualtrics_api.clj
+++ b/src/main/clojure/edmondson/qualtrics_api.clj
@@ -2,7 +2,8 @@
   (:require [clojure.string :as string]
             [clj-http.client :as client]
             [cheshire.core :as json]
-            [edmondson.config :as cfg]))
+            [edmondson.config :as cfg]
+            [edmondson.utils :as u]))
 
 (defn q-url [& args]
   (string/join "/" (cons (cfg/qualtrics-base-url) (map str args))))
@@ -80,3 +81,92 @@
                "file")
         get-json
         :responses)))
+
+
+;; Helper function which creates
+;; identifiers in the Qualtrics format.
+;; takes as input say :QID and "42" and creates keyword :QID_42_TEXT
+(defn- create-text-qid
+  [qid & args] ;; :QID "42" -> :QID_42_TEXT
+  (->> (concat [(name qid)] args ["TEXT"]) ;;(QUID 2 TEXT)
+       (string/join "_")
+       keyword))
+
+
+;;maps qualtrics internal question ids
+;;to the user defined and semantic question names
+(defmulti index-sub-questions
+  (fn [question _]
+    (:type (:questionType question)))) ;; dispatch on question type
+                                       ;; (see Qualtrics API)
+
+
+;; Multiple choice
+(defmethod index-sub-questions "MC"
+  [{:keys [questionType questionName choices] :as question}
+   qid]
+  ;;process choices with text entry
+  (reduce
+   (fn [acc [choice-id choice]]
+     (let [full-choice-id (create-text-qid qid (name choice-id))]
+       (if (contains? choice :textEntry)
+         ;; Multiple choice with text entry
+         (assoc acc full-choice-id
+                (create-text-qid (keyword questionName)
+                                 (name choice-id)))
+         acc)))
+   {} choices))
+
+;; text entry
+(defmethod index-sub-questions "TE" [{:keys [questionName]} qid]
+  ;;create an additional _TEXT question
+  {(create-text-qid qid) (create-text-qid questionName)})
+
+;; other
+(defmethod index-sub-questions "DB" [question qid] {}) ;; skip
+
+(defn index-survey-questions [details]
+  (reduce
+   (fn [acc [qid question]]
+     (-> acc
+       ;assoc qualtrics id with our question name: QID42 -> EFF-TEAM_PSY-SAFE-1
+         (assoc qid (keyword (:questionName question)))
+       ;create an merge in subquestions
+         (merge (index-sub-questions question qid))))
+   {}
+   (:questions details)))
+
+(defn normalize-responses
+  [survey-details responses]
+  (let [question-names (index-survey-questions survey-details)
+        id->label #(get question-names % %)
+        meta-data-keys #{:distributionChannel
+                         :_recordId
+                         :startDate
+                         :endDate
+                         :recordedDate
+                         :status
+                         :locationLongitude
+                         :locationLatitude
+                         :progress
+                         :duration
+                         :finished}]
+    (map (fn [response]
+           (-> response
+               (assoc :meta-data (select-keys (:values response)
+                                              meta-data-keys))
+
+               (assoc :answers
+                      ;;replaces keys of type question with question labels
+                      ;; e.g. id (QID167) with labels :SM-BATCH_MVP
+                      (into {}
+                            (map (fn [[qid qval]]
+                                   (if-let [qlabel (get (:labels response) qid)]
+                                     [(id->label qid) qlabel]
+                                     [(id->label qid) qval]))
+                                 (:values response))))
+               (dissoc :displayedFields :displayedValues :values :labels)
+
+               (update :answers #(into {} (remove (comp meta-data-keys first) %)))))
+
+         responses)))

--- a/src/main/clojure/edmondson/reports.clj
+++ b/src/main/clojure/edmondson/reports.clj
@@ -1,0 +1,115 @@
+(ns edmondson.reports
+  (:require [edmondson.survey-analysis :as analysis]
+            [clojure.string :as str]))
+
+(defn fmt-number [x]
+  (when x
+    (clojure.pprint/cl-format nil "~,1f" x)))
+
+(defn question-text [question-name] question-name)
+
+(defn print-result [res]
+  (let [lookup-questions
+        (fn [qs & keyargs]
+          (let [q-texts (map question-text qs)
+                scores (map (get-in res [:question-stats
+                                         :question-stats]) qs)
+                lines (map (fn [qid qtxt score]
+                             (str (name qid) ": "
+                                  qtxt
+                                  " (" (select-keys score keyargs) ")"))
+                           qs q-texts scores)]
+            lines))]
+
+    (println "Total score: " (fmt-number (get-in res [:construct-stats :score-total])))
+    (println "Mean score: " (fmt-number (get-in res [:construct-stats :score-mean])))
+    (println "Score stddev: " (fmt-number (get-in res [:construct-stats :score-stddev])))
+
+    (println)
+    (println "Worst responses scored")
+    (println (map (comp fmt-number :mean-score)
+                  (take 5 (get-in res [:response-stats :worst-scores]))))
+
+    (println)
+    (println "Best responses scored")
+    (println (map (comp fmt-number :mean-score)
+                  (take 5 (get-in res [:response-stats :best-scores]))))
+
+    (println)
+    (println "Response score stddev")
+    (println (fmt-number (get-in res [:response-stats :response-score-stddev])))
+
+    (println)
+    (println "Worst scoring questions")
+    (let [qs (take 3 (get-in res [:question-stats :worst-questions]))
+          lines (lookup-questions qs :score-mean)]
+      (println (clojure.string/join "\n" lines)))
+
+    (println)
+    (println "Best scoring questions")
+    (let [qs (take 3 (get-in res [:question-stats :best-questions]))
+          lines (lookup-questions qs :score-mean)]
+      (println (clojure.string/join "\n" lines)))
+
+    (println)
+
+
+    (println "Varying questions")
+    (let [qs (take 3 (get-in res [:question-stats :varying-questions]))
+          lines (lookup-questions qs :score-mean :score-stddev)]
+      (println (clojure.string/join "\n" lines)))
+
+
+    (println)
+
+    (println "Stable questions")
+    (let [qs (take 3 (get-in res [:question-stats :stable-questions]))
+          lines (lookup-questions qs :score-mean :score-stddev)]
+      (println (clojure.string/join "\n" lines)))))
+
+
+(defn take-outliers
+  [n target scored-construct-results]
+  (let [worst-scores (get-in scored-construct-results [:response-stats target])
+        worst-score-ids  (map (comp :responseId meta) worst-scores)]
+    (take n worst-score-ids)))
+
+
+(defn print-analysis
+  [survey-model construct scored-responses]
+  (let [overall-scores  (analysis/aggregate-scores survey-model scored-responses)
+        construct-overall-scores (get overall-scores construct)
+        worst-outlier-responses (set (take-outliers 5 :worst-scores
+                                                    construct-overall-scores))
+        best-outlier-responses (set (take-outliers 5 :best-scores
+                                                   construct-overall-scores))
+        worst-n-responses (filter #(worst-outlier-responses (:responseId %))
+                                  scored-responses)
+        best-n-responses (filter #(best-outlier-responses (:responseId %))
+                                 scored-responses)
+
+        worst-outlier-scores  (analysis/aggregate-scores
+                               survey-model
+                               worst-n-responses)
+        best-outlier-scores  (analysis/aggregate-scores
+                              survey-model
+                              best-n-responses)
+                ]
+    (println construct)
+    (println)
+    (println "Overall scores")
+    (println)
+    (print-result construct-overall-scores)
+
+    (println)
+    (println "Worst 5 scores")
+    (println)
+    (print-result (get worst-outlier-scores construct))
+    (println)
+    (println "Best 5 scores")
+    (println)
+    (print-result (get best-outlier-scores construct))
+    (println)
+
+
+    ))

--- a/src/main/clojure/edmondson/utils.clj
+++ b/src/main/clojure/edmondson/utils.clj
@@ -1,0 +1,9 @@
+(ns edmondson.utils)
+
+(defn map-values
+  "Like map takes and returns a map.
+  Maps across the values of a map-data structure, preserving keys.
+  Example: (map-values inc {:a 1 :b 2 :c 3})
+  => {:a 2, :b 3, :c 4}"
+  [f m]
+  (reduce-kv (fn [m k v] (assoc m k (f v))) {} m))


### PR DESCRIPTION
This refactor moves logic that's dependent on API specific details into the API wrappers. 

We also refactor commonly used functions into `util` and `reports.