### PR TITLE
Show the scaled score instead of raw score in example notebook

### DIFF
--- a/examples/google_sheets/psych_safety.ipynb
+++ b/examples/google_sheets/psych_safety.ipynb
@@ -554,7 +554,7 @@
     "          scale (:scale (get model-index qid))\n",
     "          scaled-score (scale score q-scores)]\n",
     "        (some (fn [[answer qscore]] \n",
-    "                  (when (= qscore score) answer)) \n",
+    "                  (when (= qscore scaled-score) answer)) \n",
     "              q-scores)))\n",
     "\n",
     "(def worst-3-questions\n",


### PR DESCRIPTION
This seems to have been a simple typo/omission. Using the `scaled-score` instead of `score` in this display function shows the correct label for negative-scale results.